### PR TITLE
fix: remove Helm templating from Terraform plan

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,8 +103,6 @@ The following providers are used by this module:
 
 - [[provider_kubernetes]] <<provider_kubernetes,kubernetes>> (~> 2)
 
-- [[provider_helm]] <<provider_helm,helm>>
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 4)
@@ -118,10 +116,8 @@ The following resources are used by this module:
 - https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace[kubernetes_namespace.velero_namespace] (resource)
 - https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret[kubernetes_secret.velero_repo_credentials] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] (resource)
-- https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.k8s_resources] (resource)
 - https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] (resource)
 - https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.restic_repo_password] (resource)
-- https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template[helm_template.this] (data source)
 - https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] (data source)
 
 === Required Inputs
@@ -311,7 +307,6 @@ Description: the password to access the restic repositories
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |n/a
 |[[provider_kubernetes]] <<provider_kubernetes,kubernetes>> |~> 2
-|[[provider_helm]] <<provider_helm,helm>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 4
 |[[provider_null]] <<provider_null,null>> |>= 3
@@ -327,10 +322,8 @@ Description: the password to access the restic repositories
 |https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace[kubernetes_namespace.velero_namespace] |resource
 |https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret[kubernetes_secret.velero_repo_credentials] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.dependencies] |resource
-|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.k8s_resources] |resource
 |https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.this] |resource
 |https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.restic_repo_password] |resource
-|https://registry.terraform.io/providers/hashicorp/helm/latest/docs/data-sources/template[helm_template.this] |data source
 |https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml[utils_deep_merge_yaml.values] |data source
 |===
 

--- a/main.tf
+++ b/main.tf
@@ -57,17 +57,6 @@ resource "argocd_project" "this" {
   }
 }
 
-data "helm_template" "this" {
-  name      = "velero"
-  namespace = var.namespace
-  chart     = "${path.module}/charts/velero"
-  values    = [sensitive(data.utils_deep_merge_yaml.values.output)]
-}
-
-resource "null_resource" "k8s_resources" {
-  triggers = data.helm_template.this.manifests
-}
-
 data "utils_deep_merge_yaml" "values" {
   input = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
 }


### PR DESCRIPTION
## Description of the changes

This PR remove the printing of the Helm chart changes in the terraform plan, as it could reveal some sensitive data.

## Breaking change

- [x] No